### PR TITLE
[TSK-67] Feat: 기본 컴포넌트 구조에 DI 적용

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,8 +63,8 @@ dependencies {
     implementation("com.squareup.moshi:moshi:1.14.0")
     implementation("com.squareup.moshi:moshi-kotlin:1.14.0")
     //Dagger-Hilt
-    implementation("com.google.dagger:hilt-android:2.48")
-    kapt("com.google.dagger:hilt-android-compiler:2.48")
+    implementation("com.google.dagger:hilt-android:2.47")
+    kapt("com.google.dagger:hilt-android-compiler:2.47")
     //Navigation
     implementation("androidx.navigation:navigation-compose:2.7.6")
     implementation("androidx.hilt:hilt-navigation-compose:1.1.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
+        android:name=".MyApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/wafflestudio/bunnybunny/MainActivity.kt
+++ b/app/src/main/java/com/wafflestudio/bunnybunny/MainActivity.kt
@@ -11,7 +11,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.wafflestudio.bunnybunny.ui.theme.BunnybunnyTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/wafflestudio/bunnybunny/MyApplication.kt
+++ b/app/src/main/java/com/wafflestudio/bunnybunny/MyApplication.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.bunnybunny
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class MyApplication: Application() {
+}

--- a/app/src/main/java/com/wafflestudio/bunnybunny/data/example/ExampleRepository.kt
+++ b/app/src/main/java/com/wafflestudio/bunnybunny/data/example/ExampleRepository.kt
@@ -1,4 +1,5 @@
 package com.wafflestudio.bunnybunny.data.example
 
 interface ExampleRepository {
+    suspend fun exampleFunction(query: String): Boolean
 }

--- a/app/src/main/java/com/wafflestudio/bunnybunny/data/example/ExampleRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/bunnybunny/data/example/ExampleRepositoryImpl.kt
@@ -1,4 +1,14 @@
 package com.wafflestudio.bunnybunny.data.example
 
-class ExampleRepositoryImpl {
+import com.wafflestudio.bunnybunny.lib.network.api.ExampleApi
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ExampleRepositoryImpl @Inject constructor(
+    private val api: ExampleApi,
+): ExampleRepository {
+    override suspend fun exampleFunction(query: String): Boolean {
+        TODO("Not yet implemented")
+    }
 }

--- a/app/src/main/java/com/wafflestudio/bunnybunny/di/ApplicationModule.kt
+++ b/app/src/main/java/com/wafflestudio/bunnybunny/di/ApplicationModule.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.bunnybunny.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+class ApplicationModule {
+}

--- a/app/src/main/java/com/wafflestudio/bunnybunny/di/ExampleModule.kt
+++ b/app/src/main/java/com/wafflestudio/bunnybunny/di/ExampleModule.kt
@@ -1,4 +1,0 @@
-package com.wafflestudio.bunnybunny.di
-
-class ExampleModule {
-}

--- a/app/src/main/java/com/wafflestudio/bunnybunny/di/NetworkModule.kt
+++ b/app/src/main/java/com/wafflestudio/bunnybunny/di/NetworkModule.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.bunnybunny.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+class NetworkModule {
+}

--- a/app/src/main/java/com/wafflestudio/bunnybunny/di/RepositoryModule.kt
+++ b/app/src/main/java/com/wafflestudio/bunnybunny/di/RepositoryModule.kt
@@ -1,0 +1,17 @@
+package com.wafflestudio.bunnybunny.di
+
+import com.wafflestudio.bunnybunny.data.example.ExampleRepository
+import com.wafflestudio.bunnybunny.data.example.ExampleRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+
+    @Binds
+    abstract fun bindsExampleRepository(impl: ExampleRepositoryImpl): ExampleRepository
+
+}

--- a/app/src/main/java/com/wafflestudio/bunnybunny/viewModel/MainViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/bunnybunny/viewModel/MainViewModel.kt
@@ -1,4 +1,11 @@
 package com.wafflestudio.bunnybunny.viewModel
 
-class MainViewModel {
-}
+import androidx.lifecycle.ViewModel
+import com.wafflestudio.bunnybunny.data.example.ExampleRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    val repository: ExampleRepository
+): ViewModel()


### PR DESCRIPTION
기본 컴포넌트에 DI를 적용했습니다.
- Singleton 이용
- gradle 내 dagger-hilt, kapt 2.47로 통일
- manfiest 내 인터넷 권한 추가 및 application name 추가

Resolves: TSK-36